### PR TITLE
Adjustment to EMB v0.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Unversioned
+
+* Adjusted to [`EnergyModelsBase` v0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0):
+  * Increased version nubmer for EMB.
+  * Model worked without adjustments.
+  * Adjustments only required for simple understanding of changes.
+
 ## Version 0.1.0 (2024-12-18)
 
 Initial version of the heat package within the [EnergyModelsX](https://github.com/EnergyModelsX) framework.

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 
 [compat]
-EnergyModelsBase = "0.8.3"
+EnergyModelsBase = "0.9.0"
 JuMP = "1.23.5"
 TimeStruct = "0.9.1"
 julia = "1.10"

--- a/examples/district_heating.jl
+++ b/examples/district_heating.jl
@@ -136,13 +136,8 @@ function generate_district_heating_example_data()
         Direct("TES-demand", nodes[4], nodes[5], Linear())
     ]
 
-    # WIP data structure
-    case = Dict(
-        :nodes => nodes,
-        :links => links,
-        :products => products,
-        :T => T,
-    )
+    # Input data structure
+    case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
     return case, model
 end
 
@@ -154,10 +149,10 @@ Function for processing the results to be represented in the a table afterwards.
 function process_district_heating_results(m, case)
     # Extract the nodes and the first strategic period from the data
     electricity_source, district_heat_source, heat_pump, TES, heat_demand =
-        case[:nodes][[1, 2, 3, 4, 5]]               # Extract all nodes
-    Power, HeatLT, HeatHT = case[:products][[1, 2, 3]]  # Extract all resources
-    dh_pipe = case[:links][2]                 # Extract the DH Pipe
-    𝒯 = case[:T]
+        get_nodes(case)[[1, 2, 3, 4, 5]]            # Extract all nodes
+    HeatLT = get_products(case)[2]                  # Extract the requried resource
+    dh_pipe = get_links(case)[2]                    # Extract the DH Pipe
+    𝒯 = get_time_struct(case)
 
     # District heating variables
     DHPipe_input = JuMP.Containers.rowtable(        # Flow into the link

--- a/test/DHcomponents_tester.jl
+++ b/test/DHcomponents_tester.jl
@@ -61,13 +61,8 @@
             ),
         ]
 
-        # WIP data structure
-        case = Dict(
-            :nodes => nodes,
-            :links => links,
-            :products => products,
-            :T => T,
-        )
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return (; case, model)
     end
     case, model = generate_data()
@@ -75,14 +70,10 @@
     m = run_model(case, model, optimizer)
 
     # Extract the individual nodes
-    𝒩 = case[:nodes]
-    ℒ = case[:links]
-    𝒫 = case[:products]
-    𝒯 = case[:T]
-    src = 𝒩[1]
-    snk = 𝒩[2]
-    pipe = ℒ[1]
-    dh_res = 𝒫[1]
+    src, snk = get_nodes(case)[1:2]
+    pipe = get_links(case)[1]
+    dh_res = get_products(case)[1]
+    𝒯 = get_time_struct(case)
 
     # Test that the heat loss is accurately calculated
     @test all(

--- a/test/HeatPump_tester.jl
+++ b/test/HeatPump_tester.jl
@@ -73,13 +73,8 @@
             Direct("power source-HP", nodes[2], nodes[3], Linear()),
         ]
 
-        # WIP data structure
-        case = Dict(
-            :nodes => nodes,
-            :links => links,
-            :products => products,
-            :T => T,
-        )
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return (; case, model, nodes, products, T)
     end
 

--- a/test/TES_tester.jl
+++ b/test/TES_tester.jl
@@ -71,13 +71,8 @@
             Direct("TES-demand", nodes[3], nodes[4], Linear()),
         ]
 
-        # WIP data structure
-        case = Dict(
-            :nodes => nodes,
-            :links => links,
-            :products => products,
-            :T => T,
-        )
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return (; case, model, nodes, products, T, op_duration)
     end
     case, model, nodes, products, T, op_duration = generate_data()

--- a/test/checks.jl
+++ b/test/checks.jl
@@ -109,9 +109,8 @@ end
             CO2,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
-
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return create_model(case, modeltype), case, modeltype
     end
 
@@ -151,7 +150,6 @@ end
     EMB.TEST_ENV = true
 
     # Resources used in the analysis
-
     Heat = ResourceCarrier("Heat", 0.0)
     CO2 = ResourceEmit("CO2", 1.0)
 
@@ -207,9 +205,8 @@ end
             CO2,
         )
 
-        # Creation of the case dictionary
-        case = Dict(:nodes => nodes, :links => links, :products => products, :T => T)
-
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return create_model(case, modeltype), case, modeltype
     end
 

--- a/test/emx_integration.jl
+++ b/test/emx_integration.jl
@@ -78,13 +78,8 @@
             Direct("exchange-demand", nodes[2], nodes[3], Linear()),
         ]
 
-        # WIP data structure
-        case = Dict(
-            :nodes => nodes,
-            :links => links,
-            :products => products,
-            :T => T,
-        )
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return (; case, model, nodes, products, T)
     end
 
@@ -124,6 +119,7 @@
             Dict(heat_use => 1),           # Energy demand and corresponding ratio
         )
 
+        nodes = get_nodes(case)
         nodes[3] = heat_demand
         push!(nodes, heat_upgrade)
         push!(nodes, power_source)
@@ -133,9 +129,9 @@
             Direct("power-upgrade", nodes[5], nodes[4], Linear()),
             Direct("upgrade-demand", nodes[4], nodes[3], Linear()),
         ]
-        case[:nodes] = nodes
-        case[:links] = links
 
+        # Input data structure
+        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
         return (; case, model, nodes, products, T)
     end
 end


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [v0.9.0 EnergyModelsBase](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0)

The adjustments required minor changes in the design of the individual tests and examples. It did not require any changes to the code itself.

> [!NOTE]  
> The link updated will be included in a separate PR to also include checks.