### PR TITLE
Updated link arguments and checks for DHPipe

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
   * Increased version nubmer for EMB.
   * Model worked without adjustments.
   * Adjustments only required for simple understanding of changes.
+* Included updated `DHPipe`:
+  * `DHPIpe` now follow a check.
+  * The arguments for `create_link` were updated.
 
 ## Version 0.1.0 (2024-12-18)
 

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -115,3 +115,26 @@ function EMB.check_node(
         "The heat_loss_factor field must be less or equal to 1."
     )
 end
+
+"""
+    EMB.check_link(l::DHPipe, 𝒯,  modeltype::EnergyModel, check_timeprofiles::Bool)
+
+This method checks that the *[`DHPipe`](@ref)* link is valid.
+
+## Checks
+ - The field `cap` is required to be non-negative.
+ - The field `pipe_length` is required to be non-negative.
+ - The field `pipe_loss_factor` is required to be non-negative.
+"""
+function EMB.check_link(l::DHPipe, 𝒯,  modeltype::EnergyModel, check_timeprofiles::Bool)
+
+    @assert_or_log(
+        all(capacity(l, t) ≥ 0 for t ∈ 𝒯),
+        "The capacity must be non-negative."
+    )
+    @assert_or_log(pipe_length(l) ≥ 0, "The pipeline length must be non-negative.")
+    @assert_or_log(
+        pipe_loss_factor(l) ≥ 0,
+        "The pipeline loss factor must be non-negative."
+    )
+end

--- a/src/model.jl
+++ b/src/model.jl
@@ -9,7 +9,7 @@ function EMB.variables_link(m, ℒˢᵘᵇ::Vector{<:DHPipe}, 𝒯, modeltype::E
 end
 
 """
-    create_link(m, 𝒯, 𝒫, l::DHPipe, modeltype::EnergyModel, formulation::EMB.Formulation)
+    create_link(m, l::DHPipe, 𝒯, 𝒫, modeltype::EnergyModel)
 
 When the link is a [`DHPipe`](@ref), the constraints for a link include a loss based on the
 difference in the temperature of the district heating resource and the ground.
@@ -18,11 +18,10 @@ In addition, a [`DHPipe`](@ref) includes a capacity with the potential for inves
 """
 function EMB.create_link(
     m,
+    l::DHPipe,
     𝒯,
     𝒫,
-    l::DHPipe,
     modeltype::EnergyModel,
-    formulation::EMB.Formulation,
 )
 
     # DH pipe in which each output corresponds to the input minus heat losses

--- a/src/structures/link.jl
+++ b/src/structures/link.jl
@@ -159,7 +159,7 @@ t_supply(l::DHPipe, t) = t_supply(resource_heat(l), t)
 """
     EMB.inputs(l::DHPipe)
 
-Return the resources transported into a given DHPipe `l`. 
+Return the resources transported into a given DHPipe `l`.
 This resource is in a standard [`DHPipe`](@ref) given by the function [`resource_heat`](@ref).
 """
 EMB.inputs(l::DHPipe) = [resource_heat(l)]
@@ -167,7 +167,7 @@ EMB.inputs(l::DHPipe) = [resource_heat(l)]
 """
     EMB.outputs(l::DHPipe)
 
-Return the resources transported out from a given DHPipe `l`. 
+Return the resources transported out from a given DHPipe `l`.
 This resource is in a standard [`DHPipe`](@ref) given by the function [`resource_heat`](@ref).
 """
 EMB.outputs(l::DHPipe) = [resource_heat(l)]


### PR DESCRIPTION
As outlined in #7, we have changed a bit how to include links within [EnergyModelsBase v0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0).

This PR accounts for these changes through:

1. adjusting the argument orders for `create_link` for `DHPipe` and
2. introducing checks for `DHPipe`. 