### PR TITLE
Fixed a bug in `t_source(n::HeatPump)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version 0.1.2 (2025-06-10)
+
+### Bugfix
+
+* The function `t_source(n::HeatPump)` did result in an error.
+  This was not tested previously and not used in the model.
+  New tests are hence included for it.
+
 ## Version 0.1.1 (2025-02-10)
 
 * Adjusted to [`EnergyModelsBase` v0.9.0](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.9.0):

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsHeat"
 uuid = "ad1b8b27-e232-4da9-b498-bea9c19a30d7"
 authors = ["Lars Hellemo, Hanne Kauko, and Till Holmes"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"

--- a/docs/src/background/bio_chp.md
+++ b/docs/src/background/bio_chp.md
@@ -67,7 +67,6 @@ The following input is required for the plant characteristics:
   This implies that you have to provide the pressure through subtracting the ambient pressure.
   The combination of the temperature and the pressure determines whether the heat is supplied as steam or as hot water.
 - ``\dot{Q}_{k}`` (`Q_h[k]` in the model as `vector[double]`) is the heat demand at the individual temperature and pressure levels ``k`` in MW.
-  The heat demands are
 - ``\dot{W}_{el}`` (`W_el` in the model as `double`) is the electric power output of the CHP plant in MW.
 
 !!! note "Vector positions"
@@ -106,7 +105,7 @@ The standard output of the model is given as
 - ``\dot{H}_F``;(`H_fuel` in the model) Input energy flow rates of biomass to BioCHP plant in MW.
 - ``C_{inv}``(`C_inv` in the model) are the capital expenditures in M\$.
 - ``C_{op,d}`` (`C_op_d` in the model) are the annual direct variable operating expenses in M\$.
-  It is assumed that the plant operate at XXX h/year at full capacity.
+  It is assumed that the plant operates at XXX h/year at full capacity.
 - ``C_{op,f}`` (`C_op_f` in the model) are the annual fixed operating expenses in M\$.
 
 !!! tip "Format of the outputs"

--- a/examples/district_heating.jl
+++ b/examples/district_heating.jl
@@ -231,7 +231,7 @@ pretty_table(table[1:4])
 
 @info(
     "Operational periods 5-8:\n" *
-    "The heat pump is used at maximum to satisfy the deman while in period 8 its utilization \n" *
+    "The heat pump is used at maximum to satisfy the demand while in period 8 its utilization \n" *
     "exceeds the demand to increase the storage level of the TES at the maximum charge capacity."
 )
 pretty_table(table[5:8])

--- a/src/structures/node.jl
+++ b/src/structures/node.jl
@@ -93,7 +93,7 @@ t_sink(n::HeatPump, t) = n.t_sink[t]
 Returns the temperature of the heat source for heat pump `n` as `TimeProfile` or in
 operational period `t`.
 """
-t_source(n::HeatPump) = n.t_sources
+t_source(n::HeatPump) = n.t_source
 t_source(n::HeatPump, t) = n.t_source[t]
 
 """

--- a/test/test_heat_pump.jl
+++ b/test/test_heat_pump.jl
@@ -13,7 +13,7 @@
         heat_sur = ResourceCarrier("Heat_surplus", 0.0)
         heat_use = ResourceCarrier("Heat_usable", 0.0)
         CO₂      = ResourceEmit("CO₂", 1.0)
-        products = [power, heat_sur, heat_use, CO₂]
+        𝒫 = [power, heat_sur, heat_use, CO₂]
 
         op_duration = 2 # Each operational period has a duration of 2
         op_number = 4   # There are in total 4 operational periods
@@ -22,27 +22,27 @@
         op_per_strat = op_duration * op_number
 
         # Creation of the time structure and global data
-        T = TwoLevel(2, 1, operational_periods; op_per_strat)
+        𝒯 = TwoLevel(2, 1, operational_periods; op_per_strat)
         model = OperationalModel(
             Dict(CO₂ => FixedProfile(10)),  # Emission cap for CO₂ in t/8h
             Dict(CO₂ => FixedProfile(0)),   # Emission price for CO₂ in EUR/t
             CO₂,                            # CO₂ instance
         )
 
-        nodes = [
+        𝒩 = [
             RefSource(
-                "surplus heat source",      # Node id
-                FixedProfile(2),         # Capacity in MW
-                FixedProfile(0),            # Variable OPEX in EUR/MW
-                FixedProfile(0),            # Fixed OPEX in EUR/8h
-                Dict(heat_sur => 1),        # Output from the Node, in this gase, heat_sur
+                "surplus heat source",
+                FixedProfile(2),
+                FixedProfile(0),
+                FixedProfile(0),
+                Dict(heat_sur => 1),
             ),
             RefSource(
-                "Power source",      # Node id
-                FixedProfile(1),         # Capacity in MW
-                FixedProfile(0),            # Variable OPEX in EUR/MW
-                FixedProfile(0),            # Fixed OPEX in EUR/8h
-                Dict(power => 1),        # Output from the Node, in this gase, heat_sur
+                "Power source",
+                FixedProfile(1),
+                FixedProfile(0),
+                FixedProfile(0),
+                Dict(power => 1),
             ),
             EMH.HeatPump(
                 "HeatPump",
@@ -66,33 +66,61 @@
             ),
         ]
 
-        # Connect all nodes with the availability node for the overall energy/mass balance
+        # Connect all 𝒩 with the availability node for the overall energy/mass balance
         links = [
-            Direct("suplus heat source-HP", nodes[1], nodes[3], Linear()),
-            Direct("HP-demand", nodes[3], nodes[4], Linear()),
-            Direct("power source-HP", nodes[2], nodes[3], Linear()),
+            Direct("suplus heat source-HP", 𝒩[1], 𝒩[3], Linear()),
+            Direct("HP-demand", 𝒩[3], 𝒩[4], Linear()),
+            Direct("power source-HP", 𝒩[2], 𝒩[3], Linear()),
         ]
 
         # Input data structure
-        case = Case(T, products, [nodes, links], [[get_nodes, get_links]])
-        return (; case, model, nodes, products, T)
+        case = Case(𝒯, 𝒫, [𝒩, links], [[get_nodes, get_links]])
+        return (; case, model)
     end
 
-    case, model, nodes, products, T = generate_data()
+    case, model = generate_data()
     optimizer = optimizer_with_attributes(HiGHS.Optimizer, MOI.Silent() => true)
     m = run_model(case, model, optimizer)
 
-    power = products[1]
-    surplus = products[2]
-    heat_use = products[3]
+    # Extract the required information from the node
+    𝒯 = get_time_struct(case)
+    𝒫 = get_products(case)
+    𝒩 = get_nodes(case)
+    power = 𝒫[1]
+    surplus = 𝒫[2]
+    heat_use = 𝒫[3]
+    hp = 𝒩[3]
 
-    # Test that the expected COP ratio is calculated
-    COP = 3.0
 
-    power_uptake = sum(JuMP.value(m[:flow_in][nodes[3], t, power]) for t ∈ T)
-    heat_delivered = sum(JuMP.value(m[:flow_out][nodes[3], t, heat_use]) for t ∈ T)
+    @testset "Access functions" begin
+        # Test that the input resources are correctly identified
+        @test inputs(hp) == Resource[surplus, power]
+        @test inputs(hp, surplus) == 1
+        @test inputs(hp, power) == 1
+        @test EMH.heat_in_resource(hp) == surplus
+        @test EMH.driving_force_resource(hp) == power
 
-    # Check the calculated COP
-    calculated_COP = heat_delivered / power_uptake
-    @test calculated_COP ≈ 3 atol = 0.01
+        # Test that the output resources are correctly identified
+        @test outputs(hp) == ResourceCarrier[heat_use]
+
+        # Test that the new functions are working
+        @test EMH.eff_carnot(hp) == FixedProfile(0.5)
+        @test all(EMH.eff_carnot(hp, t) == 0.5 for t ∈ 𝒯)
+        @test EMH.t_sink(hp) == FixedProfile(90)
+        @test all(EMH.t_sink(hp, t) == 90 for t ∈ 𝒯)
+        @test EMH.t_source(hp) == FixedProfile(29.475)
+        @test all(EMH.t_source(hp, t) == 29.475 for t ∈ 𝒯)
+        @test EMH.cap_lower_bound(hp) == 0
+    end
+
+    @testset "Mathematical description" begin
+        # Test that the expected COP ratio is calculated
+        COP = 3.0
+        power_uptake = sum(JuMP.value(m[:flow_in][hp, t, power]) for t ∈ 𝒯)
+        heat_delivered = sum(JuMP.value(m[:flow_out][hp, t, heat_use]) for t ∈ 𝒯)
+
+        # Check the calculated COP
+        calculated_COP = heat_delivered / power_uptake
+        @test calculated_COP ≈ 3 atol = 0.01
+    end
 end


### PR DESCRIPTION
There was a bug in the function resulting in an error. This bug was not impacting the functionality of `EnergyModelsHeat`, but the function can be used as well outside `EMHeat`, and hence, it is better to fix it directly.

The fix also includes a test for the future.