### PR TITLE
Adjustment to EMB v0.10

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Version 0.2.0 (2026-04-14)
+
+### Breaking changes
+
+* Adjusted to the changes introduced in [`EnergyModelsInvestments` 0.9](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl/releases/tag/v0.9.0) and [`EnergyModelsBase` 0.10](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0):
+  * Breaking change required as early retirement is now allowed.
+  * Early retirement changes the model behavior.
+  * No other changes required.
+
 ## Version 0.1.4 (2025-12-17)
 
 * Updated the format of `descriptive_names.yaml` to [`EnergyModelsGUI` v0.6.0](https://github.com/EnergyModelsX/EnergyModelsGUI.jl/releases/tag/v0.6.0).

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EnergyModelsHeat"
 uuid = "ad1b8b27-e232-4da9-b498-bea9c19a30d7"
 authors = ["Lars Hellemo, Hanne Kauko, and Till Holmes"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 EnergyModelsBase = "5d7e687e-f956-46f3-9045-6f5a5fd49f50"
@@ -9,7 +9,7 @@ JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TimeStruct = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 
 [compat]
-EnergyModelsBase = "0.9.1"
+EnergyModelsBase = "0.10.0"
 JuMP = "1.23.5"
 TimeStruct = "0.9.1"
 julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,7 +50,7 @@ Documenter.makedocs(
         ],
         "How to" => [
             "Use surplus heat for DH" => "howto/simple_conversion.md",
-            "Update models"=>"howto/update_models.md",
+            "Update models" => "howto/update_models.md",
             "Contribute to EnergyModelsHeat" => "howto/contribute.md",
         ],
         "Library" => [

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -50,6 +50,7 @@ Documenter.makedocs(
         ],
         "How to" => [
             "Use surplus heat for DH" => "howto/simple_conversion.md",
+            "Update models"=>"howto/update_models.md",
             "Contribute to EnergyModelsHeat" => "howto/contribute.md",
         ],
         "Library" => [

--- a/docs/src/howto/update_models.md
+++ b/docs/src/howto/update_models.md
@@ -1,0 +1,43 @@
+# [Update your model to the latest versions](@id how_to-update)
+
+`EnergyModelsHeat` is still in a pre-release version.
+Hence, there are frequently breaking changes occuring, although we plan to keep backwards compatibility.
+This document is designed to provide users with information regarding how they have to adjust their nodal descriptions to keep compatibility to the latest changes.
+
+## [Adjustments from 0.1.2](@id how_to-update-01)
+
+### [Thermal energy storage](@id how_to-update-01-TES)
+
+!!! warning
+    The legacy constructors for calls of the type of version 0.1 will be removed in version 0.3.
+    In addition, the adjustments will not be updated in release 0.10 as potential models will be at that time most likely more than 1 year old.
+
+Starting from version 0.1.2, we introduced a discharge capacity for [`ThermalEnergyStorage`](@ref).
+As a consequence, older versions without the discharge capacity will require an adjustment to include the discharge capacity.
+
+```julia
+# Old structure:
+ThermalEnergyStorage{CyclicRepresentative}(
+    "TES",
+    StorCapOpexFixed(FixedProfile(10), FixedProfile(0.5)),
+    StorCapOpexFixed(FixedProfile(20), FixedProfile(0.8)),
+    heat_use,
+    0.05,
+    Dict(heat_use => 1),
+    Dict(heat_use => 1),
+    ExtensionData[], # Conditional
+)
+
+# New structure:
+ThermalEnergyStorage{CyclicRepresentative}(
+    "TES",
+    StorCapOpexFixed(FixedProfile(10), FixedProfile(0.5)),
+    StorCapOpexFixed(FixedProfile(20), FixedProfile(0.8)),
+    StorOpexVar(FixedProfile(0)),
+    heat_use,
+    0.05,
+    Dict(heat_use => 1),
+    Dict(heat_use => 1),
+    ExtensionData[], # Conditional
+)
+```

--- a/docs/src/howto/update_models.md
+++ b/docs/src/howto/update_models.md
@@ -10,10 +10,11 @@ This document is designed to provide users with information regarding how they h
 
 !!! warning
     The legacy constructors for calls of the type of version 0.1 will be removed in version 0.3.
-    In addition, the adjustments will not be updated in release 0.10 as potential models will be at that time most likely more than 1 year old.
+    In addition, the adjustments will not be updated in release 0.3 as potential models will be at that time most likely more than 1 year old.
 
 Starting from version 0.1.2, we introduced a discharge capacity for [`ThermalEnergyStorage`](@ref).
-As a consequence, older versions without the discharge capacity will require an adjustment to include the discharge capacity.
+As a consequence, older versions without the discharge capacity will require an adjustment to include the [`AbstractStorageParameters`](@extref EnergyModelsBase nodes-storage-phil-capacities).
+The adjustment will **not** change the behavior of the node.
 
 ```julia
 # Old structure:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -88,6 +88,7 @@ Depth = 1
 ```@contents
 Pages = [
     "howto/simple_conversion.md",
+    "howto/update_models.md",
     "howto/contribute.md",
 ]
 Depth = 1

--- a/src/legacy_constructor.jl
+++ b/src/legacy_constructor.jl
@@ -10,6 +10,14 @@ function ThermalEnergyStorage{T}(
     input::Dict{<:Resource,<:Real},
     output::Dict{<:Resource,<:Real},
 ) where {T<:EMB.StorageBehavior}
+    @warn(
+        "The used implementation of a `ThermalEnergyStorage` will be discontinued in the near future. " *
+        "See the documentation for the new implementation including a discharge capacity.\n" *
+        "In practice, one has have to be incorporated:\n" *
+        "You must add an `AbstractStorageParameters` after the `level` parameters.\n" *
+        "It is recommended to update the existing implementation to the new version.",
+        maxlog = 1
+    )
     return ThermalEnergyStorage{T}(
         id,
         charge,
@@ -22,7 +30,6 @@ function ThermalEnergyStorage{T}(
         ExtensionData[],
     )
 end
-
 function ThermalEnergyStorage{T}(
     id,
     charge::EMB.AbstractStorageParameters,
@@ -33,6 +40,14 @@ function ThermalEnergyStorage{T}(
     output::Dict{<:Resource,<:Real},
     data::Vector{<:ExtensionData},
 ) where {T<:EMB.StorageBehavior}
+    @warn(
+        "The used implementation of a `ThermalEnergyStorage` will be discontinued in the near future. " *
+        "See the documentation for the new implementation including a discharge capacity.\n" *
+        "In practice, one has have to be incorporated:\n" *
+        "You must add an `AbstractStorageParameters` after the `level` parameters.\n" *
+        "It is recommended to update the existing implementation to the new version.",
+        maxlog = 1
+    )
     return ThermalEnergyStorage{T}(
         id,
         charge,
@@ -45,7 +60,6 @@ function ThermalEnergyStorage{T}(
         data,
     )
 end
-
 function ThermalEnergyStorage(
     id::Any,
     charge::EMB.AbstractStorageParameters,
@@ -56,6 +70,14 @@ function ThermalEnergyStorage(
     output::Dict{<:Resource,<:Real},
     data::Vector{<:ExtensionData},
 )
+    @warn(
+        "The used implementation of a `ThermalEnergyStorage` will be discontinued in the near future. " *
+        "See the documentation for the new implementation including a discharge capacity.\n" *
+        "In practice, one has have to be incorporated:\n" *
+        "You must add an `AbstractStorageParameters` after the `level` parameters.\n" *
+        "It is recommended to update the existing implementation to the new version.",
+        maxlog = 1
+    )
     return ThermalEnergyStorage{CyclicRepresentative}(
         id,
         charge,


### PR DESCRIPTION
This PR increases the dependency version number due to the new version to [v0.10.0 EnergyModelsBase](https://github.com/EnergyModelsX/EnergyModelsBase.jl/releases/tag/v0.10.0)

The adjustments did not require any changes except for dependency updates. It is however prudent to do a major version increase to maintain the potential for bug fixes in the previous version. In addition, the behavior may change when investments are included.

> [!IMPORTANT]  
> There will be an additional PR before registering the new version. This additional PR focuses on improvement of the documentation.